### PR TITLE
[FIX] Kubernetes cronjob schedule for week days

### DIFF
--- a/kubernetes/cron.yaml
+++ b/kubernetes/cron.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: confluence-vacations
 spec:
-  schedule: "0 7 * * *"
+  schedule: "0 7 * * 1-5"
   jobTemplate:
     spec:
       template:


### PR DESCRIPTION
## Issue

Cronjob schedule was set up for every single day of the week. It seems not necessary for people to receive the slack bot message during weekends.

## Fix

Kubernetes CronJob schedule was changed from `0 8 * * *` to `0 8 * * 1-5` (MON-FRI)


---
**Source**: https://en.wikipedia.org/wiki/Cron#CRON_expression


Field | Required | Allowed values | Allowed special characters | Remarks
-- | -- | -- | -- | --
Day of week | Yes | 0–6 or SUN–SAT | * , - ? L # | ? L # only in some implementations
