### PR TITLE
[FIX] Add validation checks for attendee existence

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,9 @@ const icalPromises = icalUrls.map(icalUrl => {
                 sameElse: 'DD/MM'
               });
 
-              calEvents["leave"].push(`>*${ev.attendee.params.CN}* (last day of leave is ${lastDayOfHoliday})`);
+              if (ev.attendee && ev.attendee.params) {
+                calEvents["leave"].push(`>*${ev.attendee.params.CN}* (last day of leave is ${lastDayOfHoliday})`);
+              }
             }
           }
 
@@ -49,7 +51,9 @@ const icalPromises = icalUrls.map(icalUrl => {
               }
 
               for (let i in ev.attendee) {
-                calEvents["publicHolidays"][ev.summary].push(`>*${ev.attendee[i].params.CN}*`);
+                if (ev.attendee[i] && ev.attendee[i].params) {
+                  calEvents["publicHolidays"][ev.summary].push(`>*${ev.attendee[i].params.CN}*`);
+                }
               }
             }
           }


### PR DESCRIPTION
This fixes Issue #6 

Instead of crashing upon no existence of Atendees on an event (leave or public holiday), the output would be like this (for now):

```
On Leave:
>*Jack Sparrow* (last day of leave is today)

Independence Day :
>*Joan Ark*
Portugal - Public holiday :
>*John Snow*
>*Ayra Stark*

Poland Public Holiday:
```

☝️  On Aug 15th 2019, there was an event named `Poland Public Holiday` without any invitee (`WHO` - field on Confluence), which lead to the following crash of the cronjob:
![image](https://user-images.githubusercontent.com/492108/63161836-f5607c00-c018-11e9-922d-d8c7da3c1cd7.png)
